### PR TITLE
Updated to SiraUtil 3 and Beat Saber 1.19

### DIFF
--- a/DiColors/Config.cs
+++ b/DiColors/Config.cs
@@ -13,7 +13,7 @@ namespace DiColors
 
         public virtual string Name { get; set; } = "Default";*/
 
-        [NonNullable, UseConverter(typeof(HiveVersionConverter))]
+        [NonNullable, UseConverter(typeof(VersionConverter))]
         public Version Version { get; set; } = new Version("1.0.0");
 
 		[NonNullable]

--- a/DiColors/DiColors.csproj
+++ b/DiColors/DiColors.csproj
@@ -81,11 +81,6 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="MediaLoader, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <Private>False</Private>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\MediaLoader.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <Private>False</Private>
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>

--- a/DiColors/Installers/DiCMenuInstaller.cs
+++ b/DiColors/Installers/DiCMenuInstaller.cs
@@ -16,7 +16,7 @@ namespace DiColors.Installers
             Container.Bind<DiColorsInfoView>().FromNewComponentAsViewController().AsSingle();
             Container.Bind<DiColorsMenuColorView>().FromNewComponentAsViewController().AsSingle();
             Container.Bind<DiColorsGameColorView>().FromNewComponentAsViewController().AsSingle();
-            Container.Bind<DiColorsFlowCoordinator>().FromNewComponentOnNewGameObject(nameof(DiColorsFlowCoordinator)).AsSingle();
+            Container.Bind<DiColorsFlowCoordinator>().FromNewComponentOnNewGameObject().AsSingle();
             Container.BindInterfacesTo<MenuButtonManager>().AsSingle();
         }
     }

--- a/DiColors/Plugin.cs
+++ b/DiColors/Plugin.cs
@@ -24,9 +24,9 @@ namespace DiColors
             _harmony = new Harmony("dev.auros.dicolors");
             config.Version = metadata.HVersion;
 
-            zenjector.OnApp<DiCInstaller>().WithParameters(config, metadata.HVersion);
+			zenjector.Install<DiCInstaller>(Location.App, config, metadata.HVersion);
+			zenjector.Install<DiCMenuInstaller>(Location.Menu);
             //zenjector.OnGame<DiCGameInstaller>(false);
-			zenjector.OnMenu<DiCMenuInstaller>();
         }
 
         [OnEnable]
@@ -38,7 +38,7 @@ namespace DiColors
         [OnDisable]
         public void OnDisable()
         {
-            _harmony.UnpatchAll("dev.auros.dicolors");
+            _harmony.UnpatchSelf();
         }
     }
 }

--- a/DiColors/Services/MenuColorSwapper.cs
+++ b/DiColors/Services/MenuColorSwapper.cs
@@ -6,36 +6,39 @@ using System.Collections.Generic;
 
 namespace DiColors.Services
 {
-    public class MenuColorSwapper : IInitializable, IColorable
-    {
-        private readonly Config.Menu _menuConfig;
-        private readonly MenuLightsManager _menuLightsManager;
-        private readonly MainFlowCoordinator _mainFlowCoordinator;
-        private readonly CampaignFlowCoordinator _campaignFlowCoordinator;
-        private readonly CenterStageScreenController _centerStageScreenController;
-        private readonly SoloFreePlayFlowCoordinator _soloFreePlayFlowCoordinator;
-        private readonly PartyFreePlayFlowCoordinator _partyFreePlayFlowCoordinator;
-        private readonly Dictionary<Color, SimpleColorSO> _colorDict = new Dictionary<Color, SimpleColorSO>();
-        private readonly Dictionary<Color, MenuLightsPresetSO> _lightsDict = new Dictionary<Color, MenuLightsPresetSO>();
+	public class MenuColorSwapper : IInitializable, IColorable
+	{
+		private readonly Config.Menu _menuConfig;
+		private readonly MenuLightsManager _menuLightsManager;
+		private readonly MainFlowCoordinator _mainFlowCoordinator;
+		private readonly CampaignFlowCoordinator _campaignFlowCoordinator;
+		private readonly CenterStageScreenController _centerStageScreenController;
+		private readonly SoloFreePlayFlowCoordinator _soloFreePlayFlowCoordinator;
+		private readonly PartyFreePlayFlowCoordinator _partyFreePlayFlowCoordinator;
+		private readonly Dictionary<Color, SimpleColorSO> _colorDict = new Dictionary<Color, SimpleColorSO>();
+		private readonly Dictionary<Color, MenuLightsPresetSO> _lightsDict = new Dictionary<Color, MenuLightsPresetSO>();
 
-        private SpriteRenderer feetSprite;
-        private MenuLightsPresetSO defaultMenuLights;
+		private SpriteRenderer feetSprite;
+		private MenuLightsPresetSO defaultMenuLights;
 
-        public MenuColorSwapper(Config.Menu menuConfig, MenuLightsManager menuLightsManager, MainFlowCoordinator mainFlowCoordinator, CampaignFlowCoordinator campaignFlowCoordinator,
-                                SoloFreePlayFlowCoordinator soloFreePlayFlowCoordinator, PartyFreePlayFlowCoordinator partyFreePlayFlowCoordinator, CenterStageScreenController centerStageScreenController)
-        {
-            _menuConfig = menuConfig;
-            _menuLightsManager = menuLightsManager;
-            _mainFlowCoordinator = mainFlowCoordinator;
-            _campaignFlowCoordinator = campaignFlowCoordinator;
-            _centerStageScreenController = centerStageScreenController;
-            _soloFreePlayFlowCoordinator = soloFreePlayFlowCoordinator;
-            _partyFreePlayFlowCoordinator = partyFreePlayFlowCoordinator;
-        }
+		public MenuColorSwapper(Config.Menu menuConfig, MenuLightsManager menuLightsManager, MainFlowCoordinator mainFlowCoordinator, CampaignFlowCoordinator campaignFlowCoordinator,
+								SoloFreePlayFlowCoordinator soloFreePlayFlowCoordinator, PartyFreePlayFlowCoordinator partyFreePlayFlowCoordinator, CenterStageScreenController centerStageScreenController)
+		{
+			_menuConfig = menuConfig;
+			_menuLightsManager = menuLightsManager;
+			_mainFlowCoordinator = mainFlowCoordinator;
+			_campaignFlowCoordinator = campaignFlowCoordinator;
+			_centerStageScreenController = centerStageScreenController;
+			_soloFreePlayFlowCoordinator = soloFreePlayFlowCoordinator;
+			_partyFreePlayFlowCoordinator = partyFreePlayFlowCoordinator;
+		}
 
-        public Color Color => _menuConfig.Enabled ? _menuConfig.DefaultColor : defaultMenuLights.lightIdColorPairs[0].baseColor;
-
-        public void Initialize()
+		public Color Color
+		{
+			get => _menuConfig.Enabled ? _menuConfig.DefaultColor : defaultMenuLights.lightIdColorPairs[0].baseColor;
+			set { }
+		}
+		public void Initialize()
         {
             defaultMenuLights = _menuLightsManager.GetField<MenuLightsPresetSO, MenuLightsManager>("_defaultPreset");
             var playersPlace = GameObject.Find("PlayersPlace");

--- a/DiColors/ViewControllers/DiColorsMenuColorView.cs
+++ b/DiColors/ViewControllers/DiColorsMenuColorView.cs
@@ -1,6 +1,7 @@
 using Zenject;
 using UnityEngine;
 using DiColors.Services;
+using System.Threading.Tasks;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.ViewControllers;
@@ -247,7 +248,7 @@ namespace DiColors.ViewControllers
         {
             parserParams.EmitEvent("apply");
             _fader.FadeOut();
-            await SiraUtil.Utilities.AwaitSleep(500);
+            await Task.Delay(500);
             _transitioner.RestartGame();
         }
 

--- a/DiColors/manifest.json
+++ b/DiColors/manifest.json
@@ -3,12 +3,12 @@
   "id": "DiColors",
   "name": "DiColors",
   "author": "Auros",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A mod which allows you to change the color of various things including the note arrow color, brightness, and menu lights.",
-  "gameVersion": "1.17.0",
+  "gameVersion": "1.19.0",
   "dependsOn": {
-    "BSIPA": "^4.0.0",
-    "SiraUtil": "^2.3.1",
-    "BeatSaberMarkupLanguage": "^1.4.0"
+    "BSIPA": "^4.2.0",
+    "SiraUtil": "^3.0.3",
+    "BeatSaberMarkupLanguage": "^1.6.1"
   }
 }


### PR DESCRIPTION
- Bumped version and dependency versions in manifest.json
- updated to zenjector.install from zenjector.OnGame in Plugin.cs
- fixed VersionConverter class call in Config.cs
- Swapped to task.delay from sirautil's awaitSleep in DiColorsMenuColorView.cs
- Fixed color struct in MenuColorSwapper.cs
- Removed unused reference to mediaLoader

Tested working and fully functional in beat saber 1.19.0